### PR TITLE
ワクチン接種オープンデータに空行がある場合を考慮

### DIFF
--- a/main.js
+++ b/main.js
@@ -487,9 +487,18 @@ const getInjections = function (
 
   let table = obj.body;
   for (let r of table) {
-    let p = parseInt(r['1回目接種完了']);
-    let q = parseInt(r['2回目接種完了']);
+    if (r['完了_年月日'] === null || r['完了_年月日'] === "") {
+      break;
+    }
     key = moment(r['完了_年月日'], 'YYYY/M/D').format('YYYY/M/D');
+    let p = parseInt(r['1回目接種完了']);
+    if (isNaN(p)) {
+      p = 0;
+    }
+    let q = parseInt(r['2回目接種完了']);
+    if (isNaN(q)) {
+      q = 0;
+    }
     firsts.push(p);
     seconds.push(q);
     labels.push(key);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/32870500/128281929-a74ed4e5-5bcd-4ebf-a867-8045f9a1f61e.png)
カンマだけの空行データがある場合にデータがおかしくなっていたため、以下修正。
・完了年月日が""or nullの場合は、データとしてカウントしない
・1・2回目接種完了者数のデータが数値でない場合、0に置き換える